### PR TITLE
Custom jwt strategy names

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ The following default options will be mixed in with the settings you pass in whe
 {
   header: 'authorization', // the default authorization header
   path: '/authentication', // the server side authentication service path
+  jwtStrategy: 'jwt', // the name of the JWT authentication strategy 
   entity: 'user', // the entity you are authenticating (ie. a users)
   service: 'users', // the service to look up the entity
   cookie: 'feathers-jwt', // the name of the cookie to parse the JWT from when cookies are enabled server side

--- a/src/index.js
+++ b/src/index.js
@@ -5,6 +5,7 @@ const defaults = {
   header: 'authorization',
   cookie: 'feathers-jwt',
   storageKey: 'feathers-jwt',
+  jwtStrategy: 'jwt', 
   path: '/authentication',
   entity: 'user',
   service: 'users'

--- a/src/passport.js
+++ b/src/passport.js
@@ -62,7 +62,7 @@ export default class Passport {
             // it with the server automatically.
             if (socket.authenticated) {
               const data = {
-                strategy: 'jwt',
+                strategy: this.options.jwtStrategy,
                 accessToken: app.get('accessToken'),
               };
               this.authenticateSocket(data, socket, emit)
@@ -83,7 +83,7 @@ export default class Passport {
               // it with the server automatically.
               if (socket.authenticated) {
                 const data = {
-                  strategy: 'jwt',
+                  strategy: this.options.jwtStrategy,
                   accessToken: app.get('accessToken'),
                 };
                 this.authenticateSocket(data, socket, emit)
@@ -113,13 +113,13 @@ export default class Passport {
     // If no strategy was given let's try to authenticate with a stored JWT
     if (!credentials.strategy) {
       if (credentials.accessToken) {
-        credentials.strategy = 'jwt';
+        credentials.strategy = this.options.jwtStrategy;
       } else {
         getCredentials = this.getJWT().then(accessToken => {
           if (!accessToken) {
             return Promise.reject(new errors.NotAuthenticated(`Could not find stored JWT and no authentication strategy was given`));
           }
-          return { strategy: 'jwt', accessToken };
+          return { strategy: this.options.jwtStrategy, accessToken };
         });
       }
     }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,6 +25,10 @@ describe('Feathers Authentication Client', () => {
       expect(client.passport.options.storageKey).to.equal('feathers-jwt');
     });
 
+    it('sets the jwtStrategy', () => {
+      expect(client.passport.options.jwtStrategy).to.equal('jwt');
+    });
+
     it('sets the auth service path', () => {
       expect(client.passport.options.path).to.equal('/authentication');
     });


### PR DESCRIPTION
### Summary

Adding support on the client so that you use a custom JWT strategy name. This allows you to support multiple JWT auth strategies on the server side like so:

```js
.configure(jwt({
  name: 'jwt',
  entity: 'user',
  service: 'users'
}))
.configure(jwt({
  name: 'jwt-device',
  entity: 'device',
  service: 'devices'
}));
```