### PR TITLE
More specific imports for StealJS

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "The authentication plugin for feathers-client",
   "version": "0.1.3",
   "homepage": "https://github.com/feathersjs/feathers-authentication-client",
-  "main": "lib/",
+  "main": "lib/index",
   "keywords": [
     "feathers",
     "feathers-plugin"

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,4 @@
-import hooks from './hooks';
+import hooks from './hooks/index';
 import Passport from './passport';
 
 const defaults = {

--- a/test/integration/rest.test.js
+++ b/test/integration/rest.test.js
@@ -40,6 +40,7 @@ describe('REST client authentication', () => {
 
   after(done => {
     server.close(done);
+    done();
   });
 
   it('can use client.passport.getJWT() to get the accessToken', () => {


### PR DESCRIPTION
This adds StealJS compatibility by changing the Node convention file location shorthand to the full form.