### PR TITLE
Hoist upgrade handler into current scope by using an arrow function

### DIFF
--- a/src/passport.js
+++ b/src/passport.js
@@ -52,7 +52,7 @@ export default class Passport {
       }
     });
 
-    function socketUpgradeHandler () {
+    const socketUpgradeHandler = () => {
       socket.io.engine.on('upgrade', () => {
         debug('Socket upgrading');
 
@@ -73,7 +73,7 @@ export default class Passport {
             });
         }
       });
-    }
+    };
 
     if (socket.io && socket.io.engine) {
       socketUpgradeHandler();


### PR DESCRIPTION
Makes sure that the scope for `this` is correct when calling the `socketUpgradeHandler` function.

Closes #26 