### PR TITLE
Add support for socket timeouts and some refactoring

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,8 @@ const defaults = {
   jwtStrategy: 'jwt',
   path: '/authentication',
   entity: 'user',
-  service: 'users'
+  service: 'users',
+  timeout: 5000
 };
 
 export default function init (config = {}) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,44 @@
+export class Storage {
+  constructor () {
+    this.store = {};
+  }
+
+  getItem (key) {
+    return this.store[key];
+  }
+
+  setItem (key, value) {
+    return (this.store[key] = value);
+  }
+
+  removeItem (key) {
+    delete this.store[key];
+    return this;
+  }
+}
+
+// Pass a decoded payload and it will return a boolean based on if it hasn't expired.
+export function payloadIsValid (payload) {
+  return payload && payload.exp * 1000 > new Date().getTime();
+}
+
+export function getCookie (name) {
+  if (typeof document !== 'undefined') {
+    const value = `; ${document.cookie}`;
+    const parts = value.split(`; ${name}=`);
+
+    if (parts.length === 2) {
+      return parts.pop().split(';').shift();
+    }
+  }
+
+  return null;
+}
+
+export function clearCookie (name) {
+  if (typeof document !== 'undefined') {
+    document.cookie = `${name}=;expires=Thu, 01 Jan 1970 00:00:01 GMT;`;
+  }
+
+  return null;
+}

--- a/test/integration/primus.test.js
+++ b/test/integration/primus.test.js
@@ -78,6 +78,17 @@ describe('Primus client authentication', function () {
     });
   });
 
+  it('supports socket timeouts', () => {
+    return client.passport.connected().then(() => {
+      client.passport.options.timeout = 0;
+
+      return client.authenticate(options).catch(error => {
+        client.passport.options.timeout = 5000;
+        expect(error.message).to.equal('Authentication timed out');
+      });
+    });
+  });
+
   it('local username password authentication and access to protected service', () => {
     return client.authenticate(options).then(response => {
       expect(response.accessToken).to.not.equal(undefined);

--- a/test/integration/socketio.test.js
+++ b/test/integration/socketio.test.js
@@ -71,6 +71,17 @@ describe('Socket.io client authentication', function () {
     });
   });
 
+  it('supports socket timeouts', () => {
+    return client.passport.connected().then(() => {
+      client.passport.options.timeout = 0;
+
+      return client.authenticate(options).catch(error => {
+        client.passport.options.timeout = 5000;
+        expect(error.message).to.equal('Authentication timed out');
+      });
+    });
+  });
+
   it('local username password authentication and access to protected service', () => {
     return client.authenticate(options).then(response => {
       expect(response.accessToken).to.not.equal(undefined);


### PR DESCRIPTION
This adds supports for authentication timeouts with sockets and moves the non-class bound utility methods into its own library. Closes #19