### PR TITLE
Note that auth must be configured after rest/socket clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ const auth = require('feathers-authentication-client');
 
 const client = feathers();
 
+// NOTE: the order is important: auth must be configured _after_ rest/socket
 client.configure(hooks())
   .configure(rest('http://localhost:3030').superagent(superagent))
   .configure(auth({ storage: localStorage }));


### PR DESCRIPTION
It would be useful to note in the documentation that the `auth` client must be configured _after_ the `rest` client. If they're configured in the opposite order, the auth token doesn't get added to the request header.