### PR TITLE
Catch getJWT promise errors

### DIFF
--- a/src/passport.js
+++ b/src/passport.js
@@ -244,7 +244,7 @@ export default class Passport {
 
   getJWT () {
     const app = this.app;
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const accessToken = app.get('accessToken');
 
       if (accessToken) {
@@ -260,7 +260,8 @@ export default class Passport {
           }
 
           return resolve(token);
-        });
+        })
+        .catch(reject);
     });
   }
 


### PR DESCRIPTION
Malformed tokens (undefined, random string) can make payload validation code to throw an Error, that will not be caught and the function that have called getJWT will hang. It would be nicer to catch such error.