### PR TITLE
Expose logoutSocket

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -27,7 +27,7 @@ declare namespace feathersAuthClient {
     connected(): Promise<any>;
     authenticate(credentials?: Credentials): any;
     authenticateSocket(credentials: Credentials, socket: any, emit: any): any;
-    logoutSocket(socket: any, emit: any): Promise<any>;
+    logoutSocket(): Promise<any>;
     logout(): Promise<any>;
     setJWT(data: any): Promise<any>;
     getJWT(): Promise<any>;

--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,7 @@ export default function init (config = {}) {
     app.passport = new Passport(app, options);
     app.authenticate = app.passport.authenticate.bind(app.passport);
     app.logout = app.passport.logout.bind(app.passport);
+    app.logoutSocket = app.passport.logoutSocket.bind(app.passport);
 
     // Set up hook that adds token and user to params so that
     // it they can be accessed by client side hooks and services

--- a/src/passport.js
+++ b/src/passport.js
@@ -189,14 +189,19 @@ export default class Passport {
     });
   }
 
-  logoutSocket (socket, emit) {
+  logoutSocket () {
+    const app = this.app;
+
+    const method = app.io ? 'emit' : 'send';
+    const socket = app.io ? app.io : app.primus;
+
     return new Promise((resolve, reject) => {
       const timeout = setTimeout(() => {
         debug('logoutSocket timed out');
         reject(new Error('Logout timed out'));
       }, this.options.timeout);
 
-      socket[emit]('logout', error => {
+      socket[method]('logout', error => {
         clearTimeout(timeout);
         socket.authenticated = false;
 
@@ -216,19 +221,17 @@ export default class Passport {
     this.clearCookie(this.options.cookie);
 
     // remove the accessToken from localStorage
-    return Promise.resolve(app.get('storage').removeItem(this.options.storageKey)).then(() => {
-      // If using sockets de-authenticate the socket
-      if (app.io || app.primus) {
-        const method = app.io ? 'emit' : 'send';
-        const socket = app.io ? app.io : app.primus;
+    return Promise.resolve(
+      app.get('storage').removeItem(this.options.storageKey)).then(() => {
+        // If using sockets de-authenticate the socket
+        if (app.io || app.primus) {
+          return this.logoutSocket();
+        }
+      }).then(result => {
+        app.emit('logout', result);
 
-        return this.logoutSocket(socket, method);
-      }
-    }).then(result => {
-      app.emit('logout', result);
-
-      return result;
-    });
+        return result;
+      });
   }
 
   setJWT (data) {


### PR DESCRIPTION
Enables feathers client to logout (i.e. close) the socket without clearing the cookie or removing the jwt.

Useful in iOS or Android mobile app scenarios where the client proactively disconnects the socket on background/suspended app state change but without forcing user to resubmit login credentials.