### PR TITLE
Remove stateful `app.settings.accessToken`

### DIFF
--- a/lib/hooks/populate-access-token.js
+++ b/lib/hooks/populate-access-token.js
@@ -6,8 +6,10 @@ module.exports = function populateAccessToken () {
       return Promise.reject(new Error(`The 'populateAccessToken' hook should only be used as a 'before' hook.`));
     }
 
-    Object.assign(hook.params, { accessToken: app.get('storage').getItem(app.passport.options.storageKey) });
-
-    return Promise.resolve(hook);
+    return Promise.resolve(app.get('storage').getItem(app.passport.options.storageKey))
+      .then(accessToken => {
+        Object.assign(hook.params, { accessToken });
+        return hook;
+      });
   };
 };

--- a/lib/hooks/populate-access-token.js
+++ b/lib/hooks/populate-access-token.js
@@ -6,7 +6,7 @@ module.exports = function populateAccessToken () {
       return Promise.reject(new Error(`The 'populateAccessToken' hook should only be used as a 'before' hook.`));
     }
 
-    Object.assign(hook.params, { accessToken: app.get('accessToken') });
+    Object.assign(hook.params, { accessToken: app.get('storage').getItem(app.passport.options.storageKey) });
 
     return Promise.resolve(hook);
   };

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -52,7 +52,7 @@ module.exports = class Passport {
       if (socket.authenticated) {
         const data = {
           strategy: this.options.jwtStrategy,
-          accessToken: app.get('accessToken')
+          accessToken: app.get('storage').getItem(app.passport.options.storageKey)
         };
         this.authenticateSocket(data, socket, emit)
           .then(this.setJWT)
@@ -73,7 +73,7 @@ module.exports = class Passport {
         if (socket.authenticated) {
           const data = {
             strategy: this.options.jwtStrategy,
-            accessToken: app.get('accessToken')
+            accessToken: app.get('storage').getItem(app.passport.options.storageKey)
           };
 
           this.authenticateSocket(data, socket, emit)

--- a/lib/passport.js
+++ b/lib/passport.js
@@ -218,7 +218,6 @@ module.exports = class Passport {
   logout () {
     const app = this.app;
 
-    app.set('accessToken', null);
     this.clearCookie(this.options.cookie);
 
     // remove the accessToken from localStorage
@@ -241,7 +240,6 @@ module.exports = class Passport {
     const accessToken = (data && data.accessToken) ? data.accessToken : data;
 
     if (accessToken) {
-      this.app.set('accessToken', accessToken);
       this.app.get('storage').setItem(this.options.storageKey, accessToken);
     }
 
@@ -249,26 +247,16 @@ module.exports = class Passport {
   }
 
   getJWT () {
-    const app = this.app;
-    return new Promise((resolve, reject) => {
-      const accessToken = app.get('accessToken');
+    return Promise.resolve(this.storage.getItem(this.options.storageKey))
+      .then(jwt => {
+        let token = jwt || this.getCookie(this.options.cookie);
 
-      if (accessToken) {
-        return resolve(accessToken);
-      }
+        if (token && token !== 'null' && !this.payloadIsValid(decode(token))) {
+          token = undefined;
+        }
 
-      return Promise.resolve(this.storage.getItem(this.options.storageKey))
-        .then(jwt => {
-          let token = jwt || this.getCookie(this.options.cookie);
-
-          if (token && token !== 'null' && !this.payloadIsValid(decode(token))) {
-            token = undefined;
-          }
-
-          return resolve(token);
-        })
-        .catch(reject);
-    });
+        return token;
+      });
   }
 
   // Pass a jwt token, get back a payload if it's valid.

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,9 +26,9 @@
       }
     },
     "@feathersjs/authentication-jwt": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@feathersjs/authentication-jwt/-/authentication-jwt-1.0.2.tgz",
-      "integrity": "sha512-9eTum7zmZEHO4vhzd3MaBDXmf7GQcRjviEDcjsXyS4aEHCVZmkXaJg+6UUD/UGsz80Qf8YWSnMINyBEvjpLtWA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@feathersjs/authentication-jwt/-/authentication-jwt-2.0.1.tgz",
+      "integrity": "sha512-2EhgBEFLWm87ZuHcCQtahbujEgwe8++aUGj9rCcFSCWx4oz9S/0NfRH37AtKQuHpdnTG9rClLOP23KqvhOLeLQ==",
       "dev": true,
       "requires": {
         "@feathersjs/errors": "3.2.1",
@@ -36,7 +36,7 @@
         "lodash.merge": "4.6.0",
         "lodash.omit": "4.5.0",
         "lodash.pick": "4.4.0",
-        "passport-jwt": "3.0.1"
+        "passport-jwt": "4.0.0"
       }
     },
     "@feathersjs/authentication-local": {
@@ -1999,12 +1999,6 @@
       "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0=",
       "dev": true
     },
-    "hoek": {
-      "version": "2.16.3",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
-      "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0=",
-      "dev": true
-    },
     "hosted-git-info": {
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.5.0.tgz",
@@ -2310,12 +2304,6 @@
       "integrity": "sha1-o32U7ZzaLVmGXJ92/llu4fM4dB4=",
       "dev": true
     },
-    "isemail": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz",
-      "integrity": "sha1-vgPfjMPineTSxd9lASY/H6RZXpo=",
-      "dev": true
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -2457,18 +2445,6 @@
       "dev": true,
       "requires": {
         "handlebars": "4.0.11"
-      }
-    },
-    "joi": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz",
-      "integrity": "sha1-TVDDGAeRIgAP5fFq8f+OGRe3fgY=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3",
-        "isemail": "1.2.0",
-        "moment": "2.20.1",
-        "topo": "1.1.0"
       }
     },
     "js-tokens": {
@@ -2877,12 +2853,6 @@
         }
       }
     },
-    "moment": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.20.1.tgz",
-      "integrity": "sha512-Yh9y73JRljxW5QxN08Fner68eFLxM5ynNOAw2LbIB1YAGeQzZT8QFSUvkAz609Zf+IHhhaUxqZK8dG3W/+HEvg==",
-      "dev": true
-    },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
@@ -3094,27 +3064,47 @@
       }
     },
     "passport-jwt": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-3.0.1.tgz",
-      "integrity": "sha1-5Pcnba2L0lHUPG/DiIMTC5YycvY=",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/passport-jwt/-/passport-jwt-4.0.0.tgz",
+      "integrity": "sha512-BwC0n2GP/1hMVjR4QpnvqA61TxenUMlmfNjYNgK0ZAs0HK4SOQkHcSv4L328blNTLtHq7DbmvyNJiH+bn6C5Mg==",
       "dev": true,
       "requires": {
-        "jsonwebtoken": "7.4.3",
+        "jsonwebtoken": "8.3.0",
         "passport-strategy": "1.0.0"
       },
       "dependencies": {
         "jsonwebtoken": {
-          "version": "7.4.3",
-          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz",
-          "integrity": "sha1-d/UCHeBYtgWheD+hKD6ZgS5kVjg=",
+          "version": "8.3.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.3.0.tgz",
+          "integrity": "sha512-oge/hvlmeJCH+iIz1DwcO7vKPkNGJHhgkspk8OH3VKlw+mbi42WtD4ig1+VXRln765vxptAv+xT26Fd3cteqag==",
           "dev": true,
           "requires": {
-            "joi": "6.10.1",
-            "jws": "3.1.4",
+            "jws": "3.1.5",
+            "lodash.includes": "4.3.0",
+            "lodash.isboolean": "3.0.3",
+            "lodash.isinteger": "4.0.4",
+            "lodash.isnumber": "3.0.3",
+            "lodash.isplainobject": "4.0.6",
+            "lodash.isstring": "4.0.1",
             "lodash.once": "4.1.1",
-            "ms": "2.0.0",
-            "xtend": "4.0.1"
+            "ms": "2.1.1"
           }
+        },
+        "jws": {
+          "version": "3.1.5",
+          "resolved": "https://registry.npmjs.org/jws/-/jws-3.1.5.tgz",
+          "integrity": "sha512-GsCSexFADNQUr8T5HPJvayTjvPIfoyJPtLQBwn5a4WZQchcrPMPMAWcC1AzJVRDKyD6ZPROPAxgv6rfHViO4uQ==",
+          "dev": true,
+          "requires": {
+            "jwa": "1.1.5",
+            "safe-buffer": "5.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+          "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+          "dev": true
         }
       }
     },
@@ -4037,15 +4027,6 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
       "dev": true
     },
-    "topo": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz",
-      "integrity": "sha1-6ddRYV0buH3IZdsYL6HKCl71NtU=",
-      "dev": true,
-      "requires": {
-        "hoek": "2.16.3"
-      }
-    },
     "trim-right": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/trim-right/-/trim-right-1.0.1.tgz",
@@ -4223,14 +4204,12 @@
       }
     },
     "ws": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-4.0.0.tgz",
-      "integrity": "sha512-QYslsH44bH8O7/W2815u5DpnCpXWpEK44FmaHffNwgJI4JMaSZONgPBTOfrxJ29mXKbXak+LsJ2uAkDTYq2ptQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-5.2.2.tgz",
+      "integrity": "sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==",
       "dev": true,
       "requires": {
-        "async-limiter": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "ultron": "1.1.1"
+        "async-limiter": "1.0.0"
       }
     },
     "xmlhttprequest-ssl": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "changelog": "github_changelog_generator && git add CHANGELOG.md && git commit -am \"Updating changelog\"",
     "lint": "semistandard --fix",
     "mocha": "mocha --opts mocha.opts",
-    "coverage": "istanbul cover _mocha -- --opts mocha.opts",
+    "coverage": "istanbul cover node_modules/mocha/bin/_mocha -- --opts mocha.opts",
     "test": "npm run lint && npm run coverage"
   },
   "semistandard": {

--- a/test/hooks/populate-access-token.test.js
+++ b/test/hooks/populate-access-token.test.js
@@ -15,11 +15,13 @@ describe('hooks:populateAccessToken', () => {
             storageKey: 'feathers-jwt'
           }
         },
-        get: () => {return {
-          getItem(){
-            return 'my token';
-          }
-        }}
+        get: () => {
+          return {
+            getItem () {
+              return 'my token';
+            }
+          };
+        }
       }
     };
   });

--- a/test/hooks/populate-access-token.test.js
+++ b/test/hooks/populate-access-token.test.js
@@ -10,7 +10,16 @@ describe('hooks:populateAccessToken', () => {
       type: 'before',
       params: {},
       app: {
-        get: () => 'my token'
+        passport: {
+          options: {
+            storageKey: 'feathers-jwt'
+          }
+        },
+        get: () => {return {
+          getItem(){
+            return 'my token';
+          }
+        }}
       }
     };
   });

--- a/test/integration/primus.test.js
+++ b/test/integration/primus.test.js
@@ -73,7 +73,7 @@ describe('Primus client authentication', function () {
   it('local username password authentication', () => {
     return client.authenticate(options).then(response => {
       expect(response.accessToken).to.not.equal(undefined);
-      expect(client.get('accessToken')).to.deep.equal(response.accessToken);
+      expect(client.get('storage').getItem(client.passport.options.storageKey)).to.deep.equal(response.accessToken);
     });
   });
 
@@ -92,7 +92,7 @@ describe('Primus client authentication', function () {
     client.once('authenticated', response => {
       try {
         expect(response.accessToken).to.not.equal(undefined);
-        expect(client.get('accessToken')).to.deep.equal(response.accessToken);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.deep.equal(response.accessToken);
         done();
       } catch (e) {
         done(e);
@@ -141,7 +141,7 @@ describe('Primus client authentication', function () {
       expect(response.accessToken).to.not.equal(undefined);
 
       return client.authenticate().then(response => {
-        expect(client.get('accessToken')).to.equal(response.accessToken);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.equal(response.accessToken);
       });
     });
   });
@@ -152,7 +152,7 @@ describe('Primus client authentication', function () {
       return client.logout();
     })
       .then(() => {
-        expect(client.get('accessToken')).to.equal(null);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.be.undefined;
         return Promise.resolve(client.get('storage').getItem('feathers-jwt'));
       })
       .then(accessToken => {

--- a/test/integration/rest.test.js
+++ b/test/integration/rest.test.js
@@ -130,7 +130,7 @@ describe('REST client authentication', () => {
       return client.logout();
     })
       .then(() => {
-        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.be.undefined;
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.equal(undefined);
         return Promise.resolve(client.get('storage').getItem('feathers-jwt'));
       })
       .then(accessToken => {

--- a/test/integration/rest.test.js
+++ b/test/integration/rest.test.js
@@ -62,7 +62,7 @@ describe('REST client authentication', () => {
   it('local username password authentication', () => {
     return client.authenticate(options).then(response => {
       expect(response.accessToken).to.not.equal(undefined);
-      expect(client.get('accessToken')).to.deep.equal(response.accessToken);
+      expect(client.get('storage').getItem(client.passport.options.storageKey)).to.deep.equal(response.accessToken);
     });
   });
 
@@ -70,7 +70,7 @@ describe('REST client authentication', () => {
     client.once('authenticated', response => {
       try {
         expect(response.accessToken).to.not.equal(undefined);
-        expect(client.get('accessToken')).to.deep.equal(response.accessToken);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.deep.equal(response.accessToken);
         done();
       } catch (e) {
         done(e);
@@ -119,7 +119,7 @@ describe('REST client authentication', () => {
       expect(response.accessToken).to.not.equal(undefined);
 
       return client.authenticate().then(response => {
-        expect(client.get('accessToken')).to.equal(response.accessToken);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.equal(response.accessToken);
       });
     });
   });
@@ -130,7 +130,7 @@ describe('REST client authentication', () => {
       return client.logout();
     })
       .then(() => {
-        expect(client.get('accessToken')).to.equal(null);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.be.undefined;
         return Promise.resolve(client.get('storage').getItem('feathers-jwt'));
       })
       .then(accessToken => {

--- a/test/integration/socketio.test.js
+++ b/test/integration/socketio.test.js
@@ -66,7 +66,7 @@ describe('Socket.io client authentication', function () {
   it('local username password authentication', () => {
     return client.authenticate(options).then(response => {
       expect(response.accessToken).to.not.equal(undefined);
-      expect(client.get('accessToken')).to.deep.equal(response.accessToken);
+      expect(client.get('storage').getItem(client.passport.options.storageKey)).to.deep.equal(response.accessToken);
     });
   });
 
@@ -85,7 +85,7 @@ describe('Socket.io client authentication', function () {
     client.once('authenticated', response => {
       try {
         expect(response.accessToken).to.not.equal(undefined);
-        expect(client.get('accessToken')).to.deep.equal(response.accessToken);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.deep.equal(response.accessToken);
         done();
       } catch (e) {
         done(e);
@@ -134,7 +134,7 @@ describe('Socket.io client authentication', function () {
       expect(response.accessToken).to.not.equal(undefined);
 
       return client.authenticate().then(response => {
-        expect(client.get('accessToken')).to.equal(response.accessToken);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.equal(response.accessToken);
       });
     });
   });
@@ -145,7 +145,7 @@ describe('Socket.io client authentication', function () {
       return client.logout();
     })
       .then(() => {
-        expect(client.get('accessToken')).to.equal(null);
+        expect(client.get('storage').getItem(client.passport.options.storageKey)).to.be.undefined;
         return Promise.resolve(client.get('storage').getItem('feathers-jwt'));
       })
       .then(accessToken => {


### PR DESCRIPTION
### Summary

I'd like to open a discussion on eliminating the stored `accessToken` on the app object. Setting `accessToken` on the app introduces a bug in ssr where there is a stateful `accessToken` being set in the feathers object. DoneJS, for instance doesn't reload all of its client files between requests and instead uses a zone-safe storage object for cookies, etc. When another user accesses the same ssr server, `accessToken` is already set and that access token is used to access rest api's from the ssr server, resulting in a user impersonating someone else.

This pull request replaces `app.get('accessToken')` with `app.get('storage').getItem('accessToken');` `app` is a stateful object that shouldn't be used to store information about a user cookie. The storage property on the app is already used in a few places, so there's nothing added there, I am however getting rid `accessToken`, a property that might be used in places so I'm not sure of the potential pitfalls of this.

- [x] Tell us about the problem your pull request is solving.
- [x] Are there any open issues that are related to this?
- [ ] Is this PR dependent on PRs in other repos?

### Other Information

 - https://github.com/canjs/can-connect-feathers/issues/111
 - https://github.com/canjs/can-connect-feathers/issues/77
